### PR TITLE
move v2 to sub folder as per convention

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -1,0 +1,129 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2018-09-14
+### Added
+- `Parse` and `ParseBytes` functions.
+- `Marshal` and `Unmarshal` functions.
+- `Marshaler` interface.
+- `Unmarshaler` interface.
+- Content type header parameter.
+
+### Changed
+- Modify `Signer` signature.
+- Add claims directly to `JWT` struct.
+- Embed `header` to JWT.
+- Add README texts, examples and usage.
+- Rename `const.go` to `methods.go`.
+- Add prefix `New` to signing methods constructors.
+- Run `vgo` for testing (this enables testing the package against Go 1.10);
+
+### Removed
+- `Sign` and `Verify` functions.
+- Base64 encoding and deconding functions.
+- `Options` struct.
+- `Claims` struct.
+- Functions that extract JWT from contexts and requests.
+
+## [1.1.0] - 2018-08-22
+### Changed
+- Prevent expensive slice reallocation when signing a JWT.
+- Refactor tests.
+
+### Fixed
+- Signature of "none" algorithm.
+
+### Removed
+- `internal` package.
+
+## [1.0.2] - 2018-07-19
+### Removed
+- Makefile.
+- Benchmark test (unused).
+
+## [1.0.1] - 2018-07-19
+### Fixed
+- Wrap Travis CI Golang versions in quotes (for parsing issues, see [this](https://github.com/travis-ci/travis-ci/issues/9247)).
+
+## [1.0.0] - 2018-07-19
+### Added
+- AppVeyor configuration file for running tests in Windows.
+- `vgo` module file.
+
+### Changed
+- `FromContext` now receives a context key as additional parameter.
+- `FromContext` now tries to build a JWT if value in context is a string.
+- Simplified Travis CI configuration file.
+- Update README to explain the motivation to have created this library and its differences from other JWT libraries for Golang.
+
+## [0.5.0] - 2018-03-12
+### Added
+- `FromContext` function to extract a JWT object from a context.
+- `FromCookie` function to extract a JWT object from a cookie.
+
+### Changed
+- Split tests into several files in order to organize them.
+
+### Fixed
+- Example in README file.
+
+## [0.4.0] - 2018-02-16
+### Added
+- Support for "none" method.
+- Tests for "none" method.
+- Missing JWTID claim.
+- Plugable validation via validator functions.
+
+### Changed
+- `(*JWT).JWTID` method name to `(*JWT).ID`.
+
+### Fixed
+- Message in `ErrECDSASigLen`.
+
+### Removed
+- Comments from custom errors, since they are self-explanatory.
+
+## [0.3.0] - 2018-02-13
+### Changed
+- Package structure.
+
+### Removed
+- Additional packages (`jwtcrypto` and `jwtutil`).
+
+## [0.2.0] - 2018-02-06
+### Added
+- New test cases.
+- Claims' timestamps validation.
+
+### Changed
+- Tests organization.
+- Use `time.After` and `time.Before` for validating timestamps.
+- `jwtcrypto/none.None` now implements `jwtcrypto.Signer`.
+
+### Fixed
+- Panicking when private or public keys are `nil`.
+
+## 0.1.0 - 2018-02-06
+### Added
+- This changelog file.
+- README file.
+- MIT License.
+- Travis CI configuration file.
+- Makefile.
+- Git ignore file.
+- EditorConfig file.
+- This package's source code, including examples and tests.
+- Go dep files.
+
+[2.0.0]: https://github.com/gbrlsnchs/jwt/compare/v1.1.0...v2.0.0
+[1.1.0]: https://github.com/gbrlsnchs/jwt/compare/v1.0.2...v1.1.0
+[1.0.2]: https://github.com/gbrlsnchs/jwt/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/gbrlsnchs/jwt/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/gbrlsnchs/jwt/compare/v0.5.0...v1.0.0
+[0.5.0]: https://github.com/gbrlsnchs/jwt/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/gbrlsnchs/jwt/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/gbrlsnchs/jwt/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/gbrlsnchs/jwt/compare/v0.1.0...v0.2.0

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,150 @@
+# jwt (JSON Web Token for Go)
+[![JWT compatible](https://jwt.io/img/badge.svg)](https://jwt.io)
+
+[![Build Status](https://travis-ci.org/gbrlsnchs/jwt.svg?branch=master)](https://travis-ci.org/gbrlsnchs/jwt)
+[![Sourcegraph](https://sourcegraph.com/github.com/gbrlsnchs/jwt/-/badge.svg)](https://sourcegraph.com/github.com/gbrlsnchs/jwt?badge)
+[![GoDoc](https://godoc.org/github.com/gbrlsnchs/jwt?status.svg)](https://godoc.org/github.com/gbrlsnchs/jwt)
+[![Minimal Version](https://img.shields.io/badge/minimal%20version-go1.10%2B-5272b4.svg)](https://golang.org/doc/go1.10)
+[![Join the chat at https://gitter.im/gbrlsnchs/jwt](https://badges.gitter.im/gbrlsnchs/jwt.svg)](https://gitter.im/gbrlsnchs/jwt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+## About
+This package is a JWT signer, verifier and validator for [Go](https://golang.org) (or Golang).
+
+Although there are many JWT packages out there for Go, many lack support for some signing, verifying or validation methods and, when they don't, they're overcomplicated. This package tries to mimic the ease of use from [Node JWT library](https://github.com/auth0/node-jsonwebtoken)'s API while following the [Effective Go](https://golang.org/doc/effective_go.html) guidelines.
+
+Support for [JWE](https://tools.ietf.org/html/rfc7516) isn't provided. Instead, [JWS](https://tools.ietf.org/html/rfc7515) is used, narrowed down to the [JWT specification](https://tools.ietf.org/html/rfc7519).
+
+## Usage
+Full documentation [here](https://godoc.org/github.com/gbrlsnchs/jwt).
+
+### Installing
+#### Go 1.10
+`vgo get -u github.com/gbrlsnchs/jwt/v2`
+#### Go 1.11 or after
+`go get -u github.com/gbrlsnchs/jwt/v2`
+
+### Importing
+```go
+import (
+	// ...
+
+	"github.com/gbrlsnchs/jwt/v2"
+)
+```
+
+### Signing a simple JWT
+```go
+// Timestamp the beginning.
+now := time.Now()
+// Define a signer.
+hs256 := jwt.NewHS256("secret")
+jot := &jwt.JWT{
+	Issuer:         "gbrlsnchs",
+	Subject:        "someone",
+	Audience:       "gophers",
+	ExpirationTime: now.Add(24 * 30 * 12 * time.Hour).Unix(),
+	NotBefore:      now.Add(30 * time.Minute).Unix(),
+	IssuedAt:       now.Unix(),
+	ID:             "foobar",
+}
+jot.SetAlgorithm(hs256)
+jot.SetKeyID("kid")
+payload, err := jwt.Marshal(jot)
+if err != nil {
+	// handle error
+}
+token, err := hs256.Sign(payload)
+if err != nil {
+	// handle error
+}
+log.Printf("token = %s", token)
+```
+
+### Signing a JWT with public claims
+#### First, create a custom type and embed a JWT pointer in it
+```go
+type Token struct {
+	*jwt.JWT
+	IsLoggedIn  bool   `json:"isLoggedIn"`
+	CustomField string `json:"customField,omitempty"`
+}
+```
+
+#### Now initialize, marshal and sign it
+```go
+// Timestamp the beginning.
+now := time.Now()
+// Define a signer.
+hs256 := jwt.NewHS256("secret")
+jot := &Token{
+	JWT: &jwt.JWT{
+		Issuer:         "gbrlsnchs",
+		Subject:        "someone",
+		Audience:       "gophers",
+		ExpirationTime: now.Add(24 * 30 * 12 * time.Hour).Unix(),
+		NotBefore:      now.Add(30 * time.Minute).Unix(),
+		IssuedAt:       now.Unix(),
+		ID:             "foobar",
+	},
+	IsLoggedIn:  true,
+	CustomField: "myCustomField",
+}
+jot.SetAlgorithm(hs256)
+jot.SetKeyID("kid")
+payload, err := jwt.Marshal(jot)
+if err != nil {
+	// handle error
+}
+token, err := hs256.Sign(payload)
+if err != nil {
+	// handle error
+}
+log.Printf("token = %s", token)
+```
+
+### Verifying and validating a JWT
+```go
+// Timestamp the beginning.
+now := time.Now()
+// Define a signer.
+hs256 := jwt.NewHS256("secret")
+// This is a mocked token for demonstration purposes only.
+token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+	"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+	"lZ1zDoGNAv3u-OclJtnoQKejE8_viHlMtGlAxE8AE0Q"
+
+// First, extract the payload and signature.
+// This enables unmarshaling the JWT first and
+// verifying it later or vice versa.
+payload, sig, err := jwt.Parse(token)
+if err != nil {
+	// handle error
+}
+if err = hs256.Verify(payload, sig); err != nil {
+	// handle error
+}
+var jot Token
+if err = jwt.Unmarshal(payload, &jot); err != nil {
+	// handle error
+}
+
+// Validate fields.
+iatValidator := jwt.IssuedAtValidator(now)
+expValidator := jwt.ExpirationTimeValidator(now)
+audValidator := jwt.AudienceValidator("admin")
+if err = jot.Validate(iatValidator, expValidator, audValidator); err != nil {
+	switch err {
+	case jwt.ErrIatValidation:
+		// handle "iat" validation error
+	case jwt.ErrExpValidation:
+		// handle "exp" validation error
+	case jwt.ErrAudValidation:
+		// handle "aud" validation error
+	}
+}
+```
+
+## Contributing
+### How to help
+- For bugs and opinions, please [open an issue](https://github.com/gbrlsnchs/jwt/issues/new)
+- For pushing changes, please [open a pull request](https://github.com/gbrlsnchs/jwt/compare)

--- a/v2/benchmark_test.go
+++ b/v2/benchmark_test.go
@@ -1,0 +1,63 @@
+package jwt_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+const benchMock = "eyJhbGciOiJIUzI1NiIsImtpZCI6ImtpZCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MzU5NDE1NjcsImV4cCI6MTU2NzA0NTU2NywibmJmIjoxNTM1OTQzMzY3LCJqdGkiOiJCZW5jaG1hcmtTaWduIiwiYXVkIjoiYmVuY2htYXJrIiwic3ViIjoibWUiLCJpc3MiOiJnYnJsc25jaHMiLCJuYW1lIjoiZm9vYmFyIiwiaXNCZW5jaCI6dHJ1ZX0.bJSm0om7-BRCuLbICllYEAH7YsAT1cW2fdSfKcMnhOg"
+
+var benchSigner = NewHS256("benchmark")
+
+type benchToken struct {
+	*JWT
+	Name    string `json:"name,omitempty"`
+	IsBench bool   `json:"isBench"`
+}
+
+func BenchmarkSign(b *testing.B) {
+	now := time.Now()
+	jot := &benchToken{
+		JWT: &JWT{
+			Issuer:         "gbrlsnchs",
+			Subject:        "me",
+			Audience:       "benchmark",
+			ExpirationTime: now.Add(24 * 30 * 12 * time.Hour).Unix(),
+			NotBefore:      now.Add(30 * time.Minute).Unix(),
+			IssuedAt:       now.Unix(),
+			ID:             b.Name(),
+		},
+		Name:    "foobar",
+		IsBench: true,
+	}
+	jot.SetAlgorithm(benchSigner)
+	jot.SetKeyID("kid")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		payload, err := Marshal(jot)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err = benchSigner.Sign(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerify(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		payload, sig, err := Parse(benchMock)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var jot benchToken
+		if err = Unmarshal(payload, &jot); err != nil {
+			b.Fatal(err)
+		}
+		if err = benchSigner.Verify(payload, sig); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/v2/build.go
+++ b/v2/build.go
@@ -1,0 +1,10 @@
+package jwt
+
+func build(s Signer, payload, sig []byte) []byte {
+	psize := len(payload)
+	token := make([]byte, psize+1+hashSize(s))
+	n := copy(token, payload)
+	token[n] = '.'
+	enc.Encode(token[n+1:], sig)
+	return token
+}

--- a/v2/byte_size.go
+++ b/v2/byte_size.go
@@ -1,0 +1,9 @@
+package jwt
+
+func byteSize(bitSize int) int {
+	byteSize := bitSize / 8
+	if bitSize%8 > 0 {
+		return byteSize + 1
+	}
+	return byteSize
+}

--- a/v2/decode.go
+++ b/v2/decode.go
@@ -1,0 +1,9 @@
+package jwt
+
+func decodeToBytes(sig []byte) ([]byte, error) {
+	decSig := make([]byte, enc.DecodedLen(len(sig)))
+	if _, err := enc.Decode(decSig, sig); err != nil {
+		return nil, err
+	}
+	return decSig, nil
+}

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -1,0 +1,2 @@
+// Package jwt is a JSON Web Token signer, verifier and validator.
+package jwt

--- a/v2/ecdsa.go
+++ b/v2/ecdsa.go
@@ -1,0 +1,110 @@
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"errors"
+	"hash"
+	"math/big"
+)
+
+var (
+	// ErrECDSANilPrivKey is the error for trying to sign a JWT with a nil private key.
+	ErrECDSANilPrivKey = errors.New("jwt: ECDSA private key is nil")
+	// ErrECDSANilPubKey is the error for trying to verify a JWT with a nil public key.
+	ErrECDSANilPubKey = errors.New("jwt: ECDSA public key is nil")
+	// ErrECDSAVerification is the error for an invalid signature.
+	ErrECDSAVerification = errors.New("jwt: ECDSA verification failed")
+)
+
+type ecdsasha struct {
+	priv *ecdsa.PrivateKey
+	pub  *ecdsa.PublicKey
+	hash func() hash.Hash
+	alg  string
+}
+
+// NewES256 creates a signing method using ECDSA and SHA-256.
+func NewES256(priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey) Signer {
+	return &ecdsasha{priv: priv, pub: pub, hash: sha256.New, alg: MethodES256}
+}
+
+// NewES384 creates a signing method using ECDSA and SHA-384.
+func NewES384(priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey) Signer {
+	return &ecdsasha{priv: priv, pub: pub, hash: sha512.New384, alg: MethodES384}
+}
+
+// NewES512 creates a signing method using ECDSA and SHA-512.
+func NewES512(priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey) Signer {
+	return &ecdsasha{priv: priv, pub: pub, hash: sha512.New, alg: MethodES512}
+}
+
+func (e *ecdsasha) Sign(payload []byte) ([]byte, error) {
+	if e.priv == nil {
+		return nil, ErrECDSANilPrivKey
+	}
+	sig, err := e.sign(payload)
+	if err != nil {
+		return nil, err
+	}
+	return build(e, payload, sig), nil
+}
+
+func (e *ecdsasha) String() string {
+	return e.alg
+}
+
+func (e *ecdsasha) Verify(payload, sig []byte) (err error) {
+	if e.pub == nil {
+		return ErrECDSANilPubKey
+	}
+	if sig, err = decodeToBytes(sig); err != nil {
+		return err
+	}
+	if err = e.verify(payload, sig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *ecdsasha) sign(payload []byte) ([]byte, error) {
+	hh := e.hash()
+	var err error
+	if _, err = hh.Write(payload); err != nil {
+		return nil, err
+	}
+	r, s, err := ecdsa.Sign(rand.Reader, e.priv, hh.Sum(nil))
+	if err != nil {
+		return nil, err
+	}
+	byteSize := byteSize(e.priv.Params().BitSize)
+	rbytes := r.Bytes()
+	rsig := make([]byte, byteSize)
+	copy(rsig[byteSize-len(rbytes):], rbytes)
+
+	sbytes := s.Bytes()
+	ssig := make([]byte, byteSize)
+	copy(ssig[byteSize-len(sbytes):], sbytes)
+	return append(rsig, ssig...), nil
+}
+
+func (e *ecdsasha) verify(payload, sig []byte) error {
+	byteSize := byteSize(e.pub.Params().BitSize)
+	if len(sig) != byteSize*2 {
+		return ErrECDSAVerification
+	}
+
+	r := big.NewInt(0).SetBytes(sig[:byteSize])
+	s := big.NewInt(0).SetBytes(sig[byteSize:])
+	hh := e.hash()
+	if _, err := hh.Write(payload); err != nil {
+		return err
+	}
+
+	if !ecdsa.Verify(e.pub, hh.Sum(nil), r, s) {
+		return ErrECDSAVerification
+	}
+	return nil
+}

--- a/v2/ecdsa_test.go
+++ b/v2/ecdsa_test.go
@@ -1,0 +1,52 @@
+package jwt_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+func TestECDSA(t *testing.T) {
+	priv256, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv256_2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv384_2, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv512, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv512_2, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCases := []testCase{
+		{NewES256(priv256, nil), NewES256(nil, &priv256.PublicKey), nil, nil, nil, nil, nil},
+		{NewES256(priv256, nil), NewES256(nil, &priv256_2.PublicKey), nil, nil, nil, nil, ErrECDSAVerification},
+		{NewES256(nil, nil), NewES256(nil, nil), nil, ErrECDSANilPrivKey, nil, nil, nil},
+		{NewES256(priv256, nil), NewES256(nil, nil), nil, nil, nil, nil, ErrECDSANilPubKey},
+		{NewES384(priv384, nil), NewES384(nil, &priv384.PublicKey), nil, nil, nil, nil, nil},
+		{NewES384(priv384, nil), NewES384(nil, &priv384_2.PublicKey), nil, nil, nil, nil, ErrECDSAVerification},
+		{NewES384(nil, nil), NewES384(nil, nil), nil, ErrECDSANilPrivKey, nil, nil, nil},
+		{NewES384(priv384, nil), NewES384(nil, nil), nil, nil, nil, nil, ErrECDSANilPubKey},
+		{NewES512(priv512, nil), NewES512(nil, &priv512.PublicKey), nil, nil, nil, nil, nil},
+		{NewES512(priv512, nil), NewES512(nil, &priv512_2.PublicKey), nil, nil, nil, nil, ErrECDSAVerification},
+		{NewES512(nil, nil), NewES512(nil, nil), nil, ErrECDSANilPrivKey, nil, nil, nil},
+		{NewES512(priv512, nil), NewES512(nil, nil), nil, nil, nil, nil, ErrECDSANilPubKey},
+	}
+	testJWT(t, testCases)
+}

--- a/v2/hash_size.go
+++ b/v2/hash_size.go
@@ -1,0 +1,19 @@
+package jwt
+
+func hashSize(s Signer) int {
+	switch s.String() {
+	case MethodHS256:
+		return enc.EncodedLen(32)
+	case MethodHS384:
+		return enc.EncodedLen(48)
+	case MethodHS512, MethodES256:
+		return enc.EncodedLen(64)
+	case MethodES384:
+		return enc.EncodedLen(96)
+	case MethodES512:
+		return enc.EncodedLen(132)
+	case MethodRS256, MethodRS384, MethodRS512:
+		return enc.EncodedLen(256)
+	}
+	return 0
+}

--- a/v2/header.go
+++ b/v2/header.go
@@ -1,0 +1,11 @@
+package jwt
+
+// header is a JOSE header narrowed down to the JWT specification from RFC 7519.
+//
+// Parameters are ordered according to the RFC 7515.
+type header struct {
+	Algorithm   string `json:"alg,omitempty"`
+	KeyID       string `json:"kid,omitempty"`
+	Type        string `json:"typ,omitempty"`
+	ContentType string `json:"cty,omitempty"`
+}

--- a/v2/hmac.go
+++ b/v2/hmac.go
@@ -1,0 +1,78 @@
+package jwt
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"errors"
+	"hash"
+)
+
+var (
+	// ErrNoHMACKey is the error for trying to sign or verify a JWT with an empty key.
+	ErrNoHMACKey = errors.New("jwt: HMAC key is empty")
+	// ErrHMACVerification is the error for an invalid signature.
+	ErrHMACVerification = errors.New("jwt: HMAC verification failed")
+)
+
+type hmacsha struct {
+	key  []byte
+	hash func() hash.Hash
+	alg  string
+}
+
+// NewHS256 creates a signing method using HMAC and SHA-256.
+func NewHS256(key string) Signer {
+	return &hmacsha{key: []byte(key), hash: sha256.New, alg: MethodHS256}
+}
+
+// NewHS384 creates a signing method using HMAC and SHA-384.
+func NewHS384(key string) Signer {
+	return &hmacsha{key: []byte(key), hash: sha512.New384, alg: MethodHS384}
+}
+
+// NewHS512 creates a signing method using HMAC and SHA-512.
+func NewHS512(key string) Signer {
+	return &hmacsha{key: []byte(key), hash: sha512.New, alg: MethodHS512}
+}
+
+func (h *hmacsha) Sign(payload []byte) ([]byte, error) {
+	sig, err := h.sign(payload)
+	if err != nil {
+		return nil, err
+	}
+	return build(h, payload, sig), nil
+}
+
+func (h *hmacsha) Verify(payload, sig []byte) (err error) {
+	if sig, err = decodeToBytes(sig); err != nil {
+		return err
+	}
+	return h.verify(payload, sig)
+}
+
+func (h *hmacsha) String() string {
+	return h.alg
+}
+
+func (h *hmacsha) sign(payload []byte) ([]byte, error) {
+	if string(h.key) == "" {
+		return nil, ErrNoHMACKey
+	}
+	hh := hmac.New(h.hash, h.key)
+	if _, err := hh.Write(payload); err != nil {
+		return nil, err
+	}
+	return hh.Sum(nil), nil
+}
+
+func (h *hmacsha) verify(payload, sig []byte) error {
+	sig2, err := h.sign(payload)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(sig, sig2) {
+		return ErrHMACVerification
+	}
+	return nil
+}

--- a/v2/hmac_test.go
+++ b/v2/hmac_test.go
@@ -1,0 +1,25 @@
+package jwt_test
+
+import (
+	"testing"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+func TestHMAC(t *testing.T) {
+	testCases := []testCase{
+		{NewHS256(""), NewHS256(""), nil, ErrNoHMACKey, nil, nil, ErrNoHMACKey},
+		{NewHS256("secret"), NewHS256("secret"), nil, nil, nil, nil, nil},
+		{NewHS256("secret"), NewHS256("not_secret"), nil, nil, nil, nil, ErrHMACVerification},
+		{NewHS256("not_secret"), NewHS256("secret"), nil, nil, nil, nil, ErrHMACVerification},
+		{NewHS384(""), NewHS384(""), nil, ErrNoHMACKey, nil, nil, ErrNoHMACKey},
+		{NewHS384("secret"), NewHS384("secret"), nil, nil, nil, nil, nil},
+		{NewHS384("secret"), NewHS384("not_secret"), nil, nil, nil, nil, ErrHMACVerification},
+		{NewHS384("not_secret"), NewHS384("secret"), nil, nil, nil, nil, ErrHMACVerification},
+		{NewHS512(""), NewHS512(""), nil, ErrNoHMACKey, nil, nil, ErrNoHMACKey},
+		{NewHS512("secret"), NewHS512("secret"), nil, nil, nil, nil, nil},
+		{NewHS512("secret"), NewHS512("not_secret"), nil, nil, nil, nil, ErrHMACVerification},
+		{NewHS512("not_secret"), NewHS512("secret"), nil, nil, nil, nil, ErrHMACVerification},
+	}
+	testJWT(t, testCases)
+}

--- a/v2/joser.go
+++ b/v2/joser.go
@@ -1,0 +1,6 @@
+package jwt
+
+type joser interface {
+	header() *header
+	setHeader(*header)
+}

--- a/v2/jwt.go
+++ b/v2/jwt.go
@@ -1,0 +1,89 @@
+package jwt
+
+import (
+	"encoding/base64"
+	"errors"
+)
+
+var enc = base64.RawURLEncoding
+
+// JWT is a JSON Web Token as per the RFC 7519.
+//
+// Fields are ordered according to the RFC 7519 order.
+type JWT struct {
+	hdr            *header
+	Issuer         string `json:"iss,omitempty"`
+	Subject        string `json:"sub,omitempty"`
+	Audience       string `json:"aud,omitempty"`
+	ExpirationTime int64  `json:"exp,omitempty"`
+	NotBefore      int64  `json:"nbf,omitempty"`
+	IssuedAt       int64  `json:"iat,omitempty"`
+	ID             string `json:"jti,omitempty"`
+}
+
+var (
+	// ErrMalformed indicates a token doesn't have
+	// a valid format, as per the RFC 7519.
+	ErrMalformed = errors.New("jwt: malformed token")
+)
+
+// Algorithm returns the JWT's header's algorithm.
+func (jot *JWT) Algorithm() string {
+	return jot.header().Algorithm
+}
+
+// ContentType returns the JWT's header's content type.
+func (jot *JWT) ContentType() string {
+	return jot.header().ContentType
+}
+
+// KeyID returns the JWT's header's key ID.
+func (jot *JWT) KeyID() string {
+	return jot.header().KeyID
+}
+
+// SetAlgorithm sets the algorithm a JWT uses to be signed.
+func (jot *JWT) SetAlgorithm(s Signer) {
+	jot.header().Algorithm = s.String()
+}
+
+// SetContentType sets the JWT's header's content type.
+//
+// This is useful if a type implements the Marshaler and the Unmarshaler
+// types in order to use JWE instead of JWS for signing and verifying.
+func (jot *JWT) SetContentType(cty string) {
+	jot.header().ContentType = cty
+}
+
+// SetKeyID sets the key ID assigned to a JWT.
+func (jot *JWT) SetKeyID(kid string) {
+	jot.header().KeyID = kid
+}
+
+// Type returns the JWT's header's type.
+func (jot *JWT) Type() string {
+	return jot.header().Type
+}
+
+// Validate validates claims and header fields.
+func (jot *JWT) Validate(validators ...ValidatorFunc) error {
+	for _, v := range validators {
+		if err := v(jot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (jot *JWT) header() *header {
+	if jot.hdr == nil {
+		jot.hdr = &header{
+			Type: "JWT",
+		}
+	}
+	return jot.hdr
+}
+
+func (jot *JWT) setHeader(hdr *header) {
+	jot.hdr = hdr
+}

--- a/v2/jwt_test.go
+++ b/v2/jwt_test.go
@@ -1,0 +1,175 @@
+package jwt_test
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+type testCase struct {
+	signer        Signer
+	verifier      Signer
+	marshalingErr error
+	signingErr    error
+	parsingErr    error
+	unmarshalErr  error
+	verifyingErr  error
+}
+
+type testToken struct {
+	*JWT
+	Name      string  `json:"name,omitempty"`
+	RandInt   int     `json:"randomInt,omitempty"`
+	RandFloat float64 `json:"randomFloat,omitempty"`
+}
+
+func testJWT(t *testing.T, testCases []testCase) {
+	for i, tc := range testCases {
+		name := fmt.Sprintf("%s %s", tc.signer.String(), tc.verifier.String())
+		t.Run(name, func(t *testing.T) {
+			now := time.Now()
+			kid := fmt.Sprintf("kid %s %d", t.Name(), i)
+			typ := "JWT"
+			cty := "JWT"
+			iat := now.Unix()
+			exp := now.Add(30 * time.Minute).Unix()
+			nbf := now.Add(1 * time.Second).Unix()
+			iss := fmt.Sprintf("%s %d", t.Name(), i)
+			aud := fmt.Sprintf("test %d", i)
+			sub := fmt.Sprintf("sub %d", i)
+			jti := strconv.Itoa(i)
+			randomInt := rand.Intn(math.MaxUint32)
+			randomFloat := rand.Float64() * 100
+			jot := &testToken{
+				JWT: &JWT{
+					Issuer:         iss,
+					Subject:        sub,
+					Audience:       aud,
+					ExpirationTime: exp,
+					NotBefore:      nbf,
+					IssuedAt:       iat,
+					ID:             jti,
+				},
+				Name:      name,
+				RandInt:   randomInt,
+				RandFloat: randomFloat,
+			}
+			jot.SetAlgorithm(tc.signer)
+			jot.SetKeyID(kid)
+			jot.SetContentType(cty)
+
+			// 1 - Marshal.
+			payload, err := Marshal(jot)
+			if want, got := tc.marshalingErr, err; want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+			if err != nil {
+				t.SkipNow()
+			}
+
+			// 2 - Sign.
+			token, err := tc.signer.Sign(payload)
+			if want, got := tc.signingErr, err; want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+			if err != nil {
+				t.SkipNow()
+			}
+
+			// 3 - Parse.
+			payload, sig, err := ParseBytes(token)
+			if want, got := tc.parsingErr, err; want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+			if err != nil {
+				t.SkipNow()
+			}
+
+			// 4 - Unmarshal.
+			var jot2 testToken
+			err = Unmarshal(payload, &jot2)
+			if want, got := tc.unmarshalErr, err; want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+			if err != nil {
+				t.SkipNow()
+			}
+
+			// 5 - Verify.
+			err = tc.verifier.Verify(payload, sig)
+			if want, got := tc.verifyingErr, err; want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+			if err != nil {
+				t.SkipNow()
+			}
+
+			// 6 - Check new token.
+			if want, got := tc.signer.String(), jot2.Algorithm(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := kid, jot2.KeyID(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := typ, jot2.Type(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := cty, jot2.ContentType(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := iat, jot2.IssuedAt; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+
+			if want, got := exp, jot2.ExpirationTime; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+
+			if want, got := nbf, jot2.NotBefore; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+
+			if want, got := iss, jot2.Issuer; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := aud, jot2.Audience; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := sub, jot2.Subject; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := jti, jot2.ID; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+
+			if want, got := randomInt, jot2.RandInt; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+
+			if want, got := randomFloat, jot2.RandFloat; want != got {
+				t.Errorf("want %f, got %f", want, got)
+			}
+
+			if want, got := reflect.ValueOf(jot).Elem().NumField(), reflect.ValueOf(&jot2).Elem().NumField(); want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+
+			if want, got := reflect.ValueOf(jot.JWT).Elem().NumField(), reflect.ValueOf(jot2.JWT).Elem().NumField(); want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+		})
+	}
+}

--- a/v2/marshal.go
+++ b/v2/marshal.go
@@ -1,0 +1,36 @@
+package jwt
+
+import "encoding/json"
+
+// Marshaler is the interface by types that can marshal a JWT description of themselves.
+type Marshaler interface {
+	MarshalJWT() ([]byte, error)
+}
+
+// Marshal marshals a struct or a pointer to a struct
+// according to RFC 7519 and returns a JWT payload encoded to Base64.
+func Marshal(v interface{}) ([]byte, error) {
+	if m, ok := v.(Marshaler); ok {
+		return m.MarshalJWT()
+	}
+	var hdr header
+	if jot, ok := v.(joser); ok {
+		hdr = *jot.header()
+	}
+	hdrBytes, err := json.Marshal(hdr)
+	if err != nil {
+		return nil, err
+	}
+	hdrSize := enc.EncodedLen(len(hdrBytes))
+	clsBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	clsSize := enc.EncodedLen(len(clsBytes))
+
+	payload := make([]byte, hdrSize+1+clsSize)
+	enc.Encode(payload, hdrBytes)
+	payload[hdrSize] = '.'
+	enc.Encode(payload[hdrSize+1:], clsBytes)
+	return payload, nil
+}

--- a/v2/methods.go
+++ b/v2/methods.go
@@ -1,0 +1,24 @@
+package jwt
+
+const (
+	// MethodHS256 is the method name for HMAC and SHA-256.
+	MethodHS256 = "HS256"
+	// MethodHS384 is the method name for HMAC and SHA-384.
+	MethodHS384 = "HS384"
+	// MethodHS512 is the method name for HMAC and SHA-512.
+	MethodHS512 = "HS512"
+	// MethodRS256 is the method name for RSA and SHA-256.
+	MethodRS256 = "RS256"
+	// MethodRS384 is the method name for RSA and SHA-384.
+	MethodRS384 = "RS384"
+	// MethodRS512 is the method name for RSA and SHA-512.
+	MethodRS512 = "RS512"
+	// MethodES256 is the method name for ECDSA and SHA-256.
+	MethodES256 = "ES256"
+	// MethodES384 is the method name for ECDSA and SHA-384.
+	MethodES384 = "ES384"
+	// MethodES512 is the method name for ECDSA and SHA-512.
+	MethodES512 = "ES512"
+	// MethodNone is the method name for an unsecured JWT.
+	MethodNone = "none"
+)

--- a/v2/none.go
+++ b/v2/none.go
@@ -1,0 +1,22 @@
+package jwt
+
+type none struct{}
+
+// None returns a Signer that
+// bypasses signing and validating,
+// thus implementing the "none" method.
+func None() Signer {
+	return &none{}
+}
+
+func (n *none) Sign(payload []byte) ([]byte, error) {
+	return build(n, payload, nil), nil
+}
+
+func (n *none) String() string {
+	return MethodNone
+}
+
+func (n *none) Verify(_, _ []byte) error {
+	return nil
+}

--- a/v2/none_test.go
+++ b/v2/none_test.go
@@ -1,0 +1,16 @@
+package jwt_test
+
+import (
+	"testing"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+func TestNone(t *testing.T) {
+	testCases := []testCase{
+		{None(), None(), nil, nil, nil, nil, nil},
+		{None(), NewHS256("secret"), nil, nil, nil, nil, ErrHMACVerification},
+		{NewHS256("secret"), None(), nil, nil, nil, nil, nil},
+	}
+	testJWT(t, testCases)
+}

--- a/v2/parse.go
+++ b/v2/parse.go
@@ -1,0 +1,24 @@
+package jwt
+
+import "bytes"
+
+// Parse returns both the payload and the signature encoded to Base64 or an error if token is invalid.
+func Parse(token string) ([]byte, []byte, error) {
+	return ParseBytes([]byte(token))
+}
+
+// ParseBytes does the same parsing as Parse but accepts a byte slice instead.
+func ParseBytes(token []byte) ([]byte, []byte, error) {
+	sep1 := bytes.IndexByte(token, '.')
+	if sep1 < 0 {
+		return nil, nil, ErrMalformed
+	}
+
+	clsBytes := token[sep1+1:]
+	sep2 := bytes.IndexByte(clsBytes, '.')
+	if sep2 < 0 {
+		return nil, nil, ErrMalformed
+	}
+	sep2 += sep1 + 1
+	return token[:sep2], token[sep2+1:], nil
+}

--- a/v2/parse_test.go
+++ b/v2/parse_test.go
@@ -1,0 +1,104 @@
+package jwt_test
+
+import (
+	"testing"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+var parserSigner = NewHS256("secret")
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		token string
+		alg   string
+		kid   string
+		typ   string
+		iss   string
+		sub   string
+		aud   string
+		exp   int64
+		nbf   int64
+		iat   int64
+		jti   string
+		name  string
+	}{
+		{
+			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+				"eyJleHAiOjE1MTYyMzkwMzMsInN1YiI6IjEyMzQ1Njc4OTAiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjIsIm5iZiI6MTUxNjIzOTA0NCwiaXNzIjoiand0LmlvIiwiYXVkIjoidGVzdCIsImp0aSI6InUzZzEyM2xrajFoZzRsMWoyZzQxaDJnIn0." +
+				"ckCc4Wa7vSsFCE8smpzFmIh9w_4MmHV1w7HndGbqA-k",
+			MethodHS256,
+			"",
+			"JWT",
+			"jwt.io",
+			"1234567890",
+			"test",
+			1516239033,
+			1516239044,
+			1516239022,
+			"u3g123lkj1hg4l1j2g41h2g",
+			"John Doe",
+		},
+		{
+			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+				"eyJzdWIiOiI0ODMyNzQ4MiIsIm5hbWUiOiJHb2xhbmcgR29waGVyIiwiaWF0IjoxNTE2MjM5MDIyfQ." +
+				"PWdAiTCf5NyNunEchIOUt6mla7ie52D3xB9ihJIBwAA",
+			MethodHS256,
+			"",
+			"JWT",
+			"",
+			"48327482",
+			"",
+			int64(0),
+			int64(0),
+			1516239022,
+			"",
+			"Golang Gopher",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			payload, sig, err := Parse(tc.token)
+			if want, got := (error)(nil), err; want != got {
+				t.Fatalf("want %v, got %v", want, got)
+			}
+			if want, got := (error)(nil), parserSigner.Verify(payload, sig); want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+			var jot testToken
+			if want, got := (error)(nil), Unmarshal(payload, &jot); want != got {
+				t.Fatalf("want %v, got %v", want, got)
+			}
+			if want, got := tc.alg, jot.Algorithm(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+			if want, got := tc.kid, jot.KeyID(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+			if want, got := tc.typ, jot.Type(); want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+			if want, got := tc.iss, jot.Issuer; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+			if want, got := tc.sub, jot.Subject; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+			if want, got := tc.aud, jot.Audience; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+			if want, got := tc.exp, jot.ExpirationTime; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+			if want, got := tc.nbf, jot.NotBefore; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+			if want, got := tc.iat, jot.IssuedAt; want != got {
+				t.Errorf("want %d, got %d", want, got)
+			}
+			if want, got := tc.jti, jot.ID; want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
+		})
+	}
+}

--- a/v2/rsa.go
+++ b/v2/rsa.go
@@ -1,0 +1,87 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+)
+
+var (
+	// ErrRSANilPrivKey is the error for trying to sign a JWT with a nil private key.
+	ErrRSANilPrivKey = errors.New("jwt: RSA private key is nil")
+	// ErrRSANilPubKey is the error for trying to verify a JWT with a nil public key.
+	ErrRSANilPubKey = errors.New("jwt: RSA public key is nil")
+)
+
+type rsasha struct {
+	priv *rsa.PrivateKey
+	pub  *rsa.PublicKey
+	hash crypto.Hash
+	alg  string
+}
+
+// NewRS256 creates a signing method using RSA and SHA-256.
+func NewRS256(priv *rsa.PrivateKey, pub *rsa.PublicKey) Signer {
+	return &rsasha{priv: priv, pub: pub, hash: crypto.SHA256, alg: MethodRS256}
+}
+
+// NewRS384 creates a signing method using RSA and SHA-384.
+func NewRS384(priv *rsa.PrivateKey, pub *rsa.PublicKey) Signer {
+	return &rsasha{priv: priv, pub: pub, hash: crypto.SHA384, alg: MethodRS384}
+}
+
+// NewRS512 creates a signing method using RSA and SHA-512.
+func NewRS512(priv *rsa.PrivateKey, pub *rsa.PublicKey) Signer {
+	return &rsasha{priv: priv, pub: pub, hash: crypto.SHA512, alg: MethodRS512}
+}
+
+func (r *rsasha) Sign(payload []byte) ([]byte, error) {
+	if r.priv == nil {
+		return nil, ErrRSANilPrivKey
+	}
+	sig, err := r.sign(payload)
+	if err != nil {
+		return nil, err
+	}
+	return build(r, payload, sig), nil
+}
+
+func (r *rsasha) String() string {
+	return r.alg
+}
+
+func (r *rsasha) Verify(payload, sig []byte) (err error) {
+	if r.pub == nil {
+		return ErrRSANilPubKey
+	}
+	if sig, err = decodeToBytes(sig); err != nil {
+		return err
+	}
+	if err = r.verify(payload, sig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *rsasha) sign(payload []byte) ([]byte, error) {
+	hh := r.hash.New()
+	var err error
+	if _, err = hh.Write(payload); err != nil {
+		return nil, err
+	}
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, r.priv, r.hash, hh.Sum(nil))
+	if err != nil {
+		return nil, err
+	}
+	return sig, nil
+}
+
+func (r *rsasha) verify(payload, sig []byte) error {
+	hh := r.hash.New()
+	if _, err := hh.Write(payload); err != nil {
+		return err
+	}
+	return rsa.VerifyPKCS1v15(r.pub, r.hash, hh.Sum(nil), sig)
+}

--- a/v2/rsa_test.go
+++ b/v2/rsa_test.go
@@ -1,0 +1,35 @@
+package jwt_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+func TestRSA(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv2, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCases := []testCase{
+		{NewRS256(priv, nil), NewRS256(nil, &priv.PublicKey), nil, nil, nil, nil, nil},
+		{NewRS256(priv, nil), NewRS256(nil, &priv2.PublicKey), nil, nil, nil, nil, rsa.ErrVerification},
+		{NewRS256(nil, nil), NewRS256(nil, nil), nil, ErrRSANilPrivKey, nil, nil, nil},
+		{NewRS256(priv, nil), NewRS256(nil, nil), nil, nil, nil, nil, ErrRSANilPubKey},
+		{NewRS384(priv, nil), NewRS384(nil, &priv.PublicKey), nil, nil, nil, nil, nil},
+		{NewRS384(priv, nil), NewRS384(nil, &priv2.PublicKey), nil, nil, nil, nil, rsa.ErrVerification},
+		{NewRS384(nil, nil), NewRS384(nil, nil), nil, ErrRSANilPrivKey, nil, nil, nil},
+		{NewRS384(priv, nil), NewRS384(nil, nil), nil, nil, nil, nil, ErrRSANilPubKey},
+		{NewRS512(priv, nil), NewRS512(nil, &priv.PublicKey), nil, nil, nil, nil, nil},
+		{NewRS512(priv, nil), NewRS512(nil, &priv2.PublicKey), nil, nil, nil, nil, rsa.ErrVerification},
+		{NewRS512(nil, nil), NewRS512(nil, nil), nil, ErrRSANilPrivKey, nil, nil, nil},
+		{NewRS512(priv, nil), NewRS512(nil, nil), nil, nil, nil, nil, ErrRSANilPubKey},
+	}
+	testJWT(t, testCases)
+}

--- a/v2/signer.go
+++ b/v2/signer.go
@@ -1,0 +1,12 @@
+package jwt
+
+// Signer is a signing method capable of
+// both signing and verifying a JWT.
+type Signer interface {
+	// Sign signs a JWT payload and returns a complete JWT (payload + signature).
+	Sign([]byte) ([]byte, error)
+	// Verify verifies a payload and a signature.
+	// It returns an error with details of why verification failed or a nil one if verification is OK.
+	Verify([]byte, []byte) error
+	String() string // prints a specific text used in the "alg" field
+}

--- a/v2/unmarshal.go
+++ b/v2/unmarshal.go
@@ -1,0 +1,48 @@
+package jwt
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Unmarshaler is the interface inmplemented by types
+// that can unmarshal a JWT description of themselves.
+type Unmarshaler interface {
+	UnmarshalJWT([]byte) error
+}
+
+// Unmarshal unmarshals a token according to RFC 7519 and assigns a JWT to an interface.
+func Unmarshal(b []byte, v interface{}) error {
+	if m, ok := v.(Unmarshaler); ok {
+		return m.UnmarshalJWT(b)
+	}
+	sep := bytes.IndexByte(b, '.')
+	if sep < 0 {
+		return ErrMalformed
+	}
+
+	encHdr := b[:sep]
+	hdrSize := enc.DecodedLen(len(encHdr))
+	decHdr := make([]byte, hdrSize)
+	if _, err := enc.Decode(decHdr, encHdr); err != nil {
+		return err
+	}
+	var hdr header
+	if err := json.Unmarshal(decHdr, &hdr); err != nil {
+		return err
+	}
+
+	encCls := b[sep+1:]
+	clsSize := enc.DecodedLen(len(encCls))
+	decCls := make([]byte, clsSize)
+	if _, err := enc.Decode(decCls, encCls); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(decCls, v); err != nil {
+		return err
+	}
+	if jot, ok := v.(joser); ok {
+		jot.setHeader(&hdr)
+	}
+	return nil
+}

--- a/v2/validators.go
+++ b/v2/validators.go
@@ -1,0 +1,97 @@
+package jwt
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrAudValidation is the error for an invalid "aud" claim.
+	ErrAudValidation = errors.New("jwt: aud claim is invalid")
+	// ErrExpValidation is the error for an invalid "exp" claim.
+	ErrExpValidation = errors.New("jwt: exp claim is invalid")
+	// ErrIatValidation is the error for an invalid "iat" claim.
+	ErrIatValidation = errors.New("jwt: iat claim is invalid")
+	// ErrIssValidation is the error for an invalid "iss" claim.
+	ErrIssValidation = errors.New("jwt: iss claim is invalid")
+	// ErrJtiValidation is the error for an invalid "jti" claim.
+	ErrJtiValidation = errors.New("jwt: jti claim is invalid")
+	// ErrNbfValidation is the error for an invalid "nbf" claim.
+	ErrNbfValidation = errors.New("jwt: nbf claim is invalid")
+	// ErrSubValidation is the error for an invalid "sub" claim.
+	ErrSubValidation = errors.New("jwt: sub claim is invalid")
+)
+
+// ValidatorFunc is a function for running extra
+// validators when parsing a JWT string.
+type ValidatorFunc func(jot *JWT) error
+
+// AudienceValidator validates the "aud" claim.
+func AudienceValidator(aud string) ValidatorFunc {
+	return func(jot *JWT) error {
+		if jot.Audience != aud {
+			return ErrAudValidation
+		}
+		return nil
+	}
+}
+
+// ExpirationTimeValidator validates the "exp" claim.
+func ExpirationTimeValidator(now time.Time) ValidatorFunc {
+	return func(jot *JWT) error {
+		if exp := time.Unix(jot.ExpirationTime, 0); now.After(exp) {
+			return ErrExpValidation
+		}
+		return nil
+	}
+}
+
+// IssuedAtValidator validates the "iat" claim.
+func IssuedAtValidator(now time.Time) ValidatorFunc {
+	return func(jot *JWT) error {
+		if iat := time.Unix(jot.IssuedAt, 0); now.Before(iat) {
+			return ErrIatValidation
+		}
+		return nil
+	}
+}
+
+// IssuerValidator validates the "iss" claim.
+func IssuerValidator(iss string) ValidatorFunc {
+	return func(jot *JWT) error {
+		if jot.Issuer != iss {
+			return ErrIssValidation
+		}
+		return nil
+	}
+}
+
+// IDValidator validates the "jti" claim.
+func IDValidator(jti string) ValidatorFunc {
+	return func(jot *JWT) error {
+		if jot.ID != jti {
+			return ErrJtiValidation
+		}
+		return nil
+	}
+}
+
+// NotBeforeValidator validates the "nbf" claim.
+func NotBeforeValidator(now time.Time) ValidatorFunc {
+	return func(jot *JWT) error {
+		if nbf := time.Unix(jot.NotBefore, 0); now.Before(nbf) {
+			return ErrNbfValidation
+		}
+		return nil
+	}
+}
+
+// SubjectValidator validates the "sub" claim.
+func SubjectValidator(sub string) ValidatorFunc {
+	return func(jot *JWT) error {
+		if jot.Subject != sub {
+			return ErrSubValidation
+		}
+		return nil
+	}
+}

--- a/v2/validators_test.go
+++ b/v2/validators_test.go
@@ -1,0 +1,57 @@
+package jwt_test
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/gbrlsnchs/jwt/v2"
+)
+
+func TestValidators(t *testing.T) {
+	var now time.Time
+	jot := &JWT{
+		IssuedAt:       now.Unix(),
+		ExpirationTime: now.Add(24 * time.Hour).Unix(),
+		NotBefore:      now.Add(15 * time.Second).Unix(),
+		ID:             "jti",
+		Audience:       "aud",
+		Subject:        "sub",
+		Issuer:         "iss",
+	}
+	testCases := []struct {
+		validator ValidatorFunc
+		err       error
+	}{
+		{IssuerValidator("iss"), nil},
+		{IssuerValidator("not_iss"), ErrIssValidation},
+		{SubjectValidator("sub"), nil},
+		{SubjectValidator("not_sub"), ErrSubValidation},
+		{AudienceValidator("aud"), nil},
+		{AudienceValidator("not_aud"), ErrAudValidation},
+		{ExpirationTimeValidator(now), nil},
+		{ExpirationTimeValidator(time.Unix(now.Unix()-int64(24*time.Hour), 0)), nil},
+		{ExpirationTimeValidator(time.Unix(now.Unix()+int64(24*time.Hour), 0)), ErrExpValidation},
+		{NotBeforeValidator(now), ErrNbfValidation},
+		{NotBeforeValidator(time.Unix(now.Unix()+int64(15*time.Second), 0)), nil},
+		{NotBeforeValidator(time.Unix(now.Unix()-int64(15*time.Second), 0)), ErrNbfValidation},
+		{IssuedAtValidator(now), nil},
+		{IssuedAtValidator(time.Unix(now.Unix()+1, 0)), nil},
+		{IssuedAtValidator(time.Unix(now.Unix()-1, 0)), ErrIatValidation},
+		{IDValidator("jti"), nil},
+		{IDValidator("not_jti"), ErrJtiValidation},
+	}
+	for _, tc := range testCases {
+		fn := runtime.FuncForPC(reflect.ValueOf(tc.validator).Pointer())
+		name := fn.Name()[:]
+		name = strings.TrimPrefix(name, "github.com/gbrlsnchs/jwt/v2.")
+		name = strings.TrimSuffix(name, ".func1")
+		t.Run(name, func(t *testing.T) {
+			if want, got := tc.err, tc.validator(jot); want != got {
+				t.Errorf("want %v, got %v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi

We are moving to go modules and we have been unable to find a workaround to consuming this package.  The issue is that there is a v2.0.0 tag (which we consume) but the v2x code is not on a different import path as per the convention so the go tool won't play nicely.

I'm pretty sure the solution is to merge this PR and then tag that revision as v2.0.1.  At least I think that will be good for us, not sure where that leaves consumers using other dependency management approaches/tools.

King Regards
Myles 